### PR TITLE
Makes it compatible (deprecation errors free) with PHP 8.*

### DIFF
--- a/lib/Api/AllowlistsApi.php
+++ b/lib/Api/AllowlistsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class AllowlistsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/ExportsApi.php
+++ b/lib/Api/ExportsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class ExportsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/InboundApi.php
+++ b/lib/Api/InboundApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class InboundApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/IpsApi.php
+++ b/lib/Api/IpsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class IpsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/MessagesApi.php
+++ b/lib/Api/MessagesApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class MessagesApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/MetadataApi.php
+++ b/lib/Api/MetadataApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class MetadataApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/RejectsApi.php
+++ b/lib/Api/RejectsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class RejectsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/SendersApi.php
+++ b/lib/Api/SendersApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class SendersApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/SubaccountsApi.php
+++ b/lib/Api/SubaccountsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class SubaccountsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/TagsApi.php
+++ b/lib/Api/TagsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class TagsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/TemplatesApi.php
+++ b/lib/Api/TemplatesApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class TemplatesApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/UrlsApi.php
+++ b/lib/Api/UrlsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class UrlsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/UsersApi.php
+++ b/lib/Api/UsersApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class UsersApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/WebhooksApi.php
+++ b/lib/Api/WebhooksApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class WebhooksApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/WhitelistsApi.php
+++ b/lib/Api/WhitelistsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class WhitelistsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -47,6 +47,22 @@ class Configuration
     protected $defaultOutputFormat = '';
     protected $timeout = 300;
 
+    protected AllowlistsApi $allowlists;
+    protected ExportsApi $exports;
+    protected InboundApi $inbound;
+    protected IpsApi $ips;
+    protected MessagesApi $messages;
+    protected MetadataApi $metadata;
+    protected RejectsApi $rejects;
+    protected SendersApi $senders;
+    protected SubaccountsApi $subaccounts;
+    protected TagsApi $tags;
+    protected TemplatesApi $templates;
+    protected UrlsApi $urls;
+    protected UsersApi $users;
+    protected WebhooksApi $webhooks;
+    protected WhitelistsApi $whitelists;
+
     public static $formatList = ['json', 'xml', 'php', 'yaml'];
 
     public function __construct()


### PR DESCRIPTION
Note: This repository is auto-generated, and does not accept pull requests.

To make changes or open issues for this SDK, use the [code generation repository](https://github.com/mailchimp/mailchimp-client-lib-codegen).
